### PR TITLE
docs: fixing wrong MD at Expandable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ import { Expandable } from '@backpackerds/primitives'
 <Expandable
   renderHeader={({ isVisible }) => <Row><H1>Expand me!</H1></Row>}>
   ...
-</Touchable>
+</Expandable>
 ```
 
 The `Expandable` primitive uses `LayoutAnimation` for a smooth expand/collapse of the content.


### PR DESCRIPTION
Fixing a small MD error on the `Expandable` example. 😅 